### PR TITLE
Proposed bug fix for search failure on home page

### DIFF
--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -5,17 +5,12 @@
             <div class="panel-heading">
             </div>
             <div class="panel-body">
-                <form class="navbar-form navbar-left" role="search">
+                <form id="searchForm" class="navbar-form navbar-left" role="search">
                     <div class="form-group">
                         <input id="searchbox" type="text" class="form-control" />
-                        <button id="searchButton" type="submit" class="btn btn-default">
+                        <button type="submit" class="btn btn-default">
                             Search
                         </button>
-  <!--                       <p>
-                            <label>
-                                <input id="chapterCheckbox" type="checkbox">Selected chapter
-                            </label>
-                        </p> -->
                     </div>
                 </form>
             </div>
@@ -28,8 +23,6 @@
             </div>
         </div>
     </div>
-    <!--<div class="col-md-1">
-                    </div>-->
     <div class="col-md-8">
         {{content}}
     </div>

--- a/_site/assets/main.js
+++ b/_site/assets/main.js
@@ -5,7 +5,7 @@ var data = $.getJSON('/assets/searchIndex.json');
 data.then(function(d) {
   store = d.store;
   index = lunr.Index.load(d.index);
-}).then(function (){  
+}).then(function (){
   var out = search(getParameterByName('q'),getParameterByName('chapter')).map(function (e){
     return "<p><a href='/chapters/" + e.section.slice(0,2) + "#" + e.section + "'>" + e.title + "</a></p>";
   }).join('')
@@ -16,7 +16,7 @@ data.then(function(d) {
  * searches the index for the query, optionally filtered by chapter
  * @param {query} the search query
  * @param {chapter} OPTIONAL: the chapter to filter on
- * @return {results} an array of results 
+ * @return {results} an array of results
  */
 function search(query, chapter) {
   var results = index.search(query).filter(function (d){
@@ -27,7 +27,7 @@ function search(query, chapter) {
 
 /**
  * maps the results of a search query to the store
- *  
+ *
  */
 function mapResultsToStore(results) {
   return results.map(function (e,i,a){
@@ -35,31 +35,26 @@ function mapResultsToStore(results) {
   })
 }
 
-// Bind search to the searchbox... 
-//$("#searchbox").keyup(function (e){
-//  console.log(search($("#searchbox").val()))
-//})
-
-$("#searchForm").submit(function (event){
-  event.preventDefault();
-  q = $("#searchbox").val();
-  url = "/search/?q=" + q
-  if ($("#chapterCheckbox").prop("checked")){
-    url = url + "&chapter=" + window.location.href.split('#')[0].split('chapters/')[1].slice(0,2)
-  }
-  window.location.href = url
-})
+function getParameterByName(name) {
+  name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+  var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
+      results = regex.exec(location.search);
+  return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+}
 
 $(document).ready(function(){
+  $("#searchForm").submit(function (event){
+    event.preventDefault();
+    q = $("#searchbox").val();
+    url = "/search/?q=" + q
+    if ($("#chapterCheckbox").prop("checked")){
+      url = url + "&chapter=" + window.location.href.split('#')[0].split('chapters/')[1].slice(0,2)
+    }
+    window.location.href = url
+  })
+
   var q = getParameterByName('q');
   if (q) {
     $("#searchbox").val(q)
   }
-})
-
-function getParameterByName(name) {
-    name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
-    var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
-        results = regex.exec(location.search);
-    return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
-}
+});

--- a/_site/index.html
+++ b/_site/index.html
@@ -43,17 +43,12 @@
             <div class="panel-heading">
             </div>
             <div class="panel-body">
-                <form class="navbar-form navbar-left" role="search">
+                <form id="searchForm" class="navbar-form navbar-left" role="search">
                     <div class="form-group">
                         <input id="searchbox" type="text" class="form-control" />
-                        <button id="searchButton" type="submit" class="btn btn-default">
+                        <button type="submit" class="btn btn-default">
                             Search
                         </button>
-  <!--                       <p>
-                            <label>
-                                <input id="chapterCheckbox" type="checkbox">Selected chapter
-                            </label>
-                        </p> -->
                     </div>
                 </form>
             </div>
@@ -104,8 +99,6 @@
             </div>
         </div>
     </div>
-    <!--<div class="col-md-1">
-                    </div>-->
     <div class="col-md-8">
         <h3 id="welcome-to-foh">Welcome to FOH</h3>
 

--- a/_site/search/index.html
+++ b/_site/search/index.html
@@ -43,17 +43,12 @@
             <div class="panel-heading">
             </div>
             <div class="panel-body">
-                <form class="navbar-form navbar-left" role="search">
+                <form id="searchForm" class="navbar-form navbar-left" role="search">
                     <div class="form-group">
                         <input id="searchbox" type="text" class="form-control" />
-                        <button id="searchButton" type="submit" class="btn btn-default">
+                        <button type="submit" class="btn btn-default">
                             Search
                         </button>
-  <!--                       <p>
-                            <label>
-                                <input id="chapterCheckbox" type="checkbox">Selected chapter
-                            </label>
-                        </p> -->
                     </div>
                 </form>
             </div>
@@ -104,8 +99,6 @@
             </div>
         </div>
     </div>
-    <!--<div class="col-md-1">
-                    </div>-->
     <div class="col-md-8">
         <h3 id="search-results">Search Results</h3>
 

--- a/assets/main.js
+++ b/assets/main.js
@@ -8,7 +8,7 @@ var data = $.getJSON('{{site.baseurl}}/assets/searchIndex.json');
 data.then(function(d) {
   store = d.store;
   index = lunr.Index.load(d.index);
-}).then(function (){  
+}).then(function (){
   var out = search(getParameterByName('q'),getParameterByName('chapter')).map(function (e){
     return "<p><a href='/chapters/" + e.section.slice(0,2) + "#" + e.section + "'>" + e.title + "</a></p>";
   }).join('')
@@ -19,7 +19,7 @@ data.then(function(d) {
  * searches the index for the query, optionally filtered by chapter
  * @param {query} the search query
  * @param {chapter} OPTIONAL: the chapter to filter on
- * @return {results} an array of results 
+ * @return {results} an array of results
  */
 function search(query, chapter) {
   var results = index.search(query).filter(function (d){
@@ -30,7 +30,7 @@ function search(query, chapter) {
 
 /**
  * maps the results of a search query to the store
- *  
+ *
  */
 function mapResultsToStore(results) {
   return results.map(function (e,i,a){
@@ -38,31 +38,26 @@ function mapResultsToStore(results) {
   })
 }
 
-// Bind search to the searchbox... 
-//$("#searchbox").keyup(function (e){
-//  console.log(search($("#searchbox").val()))
-//})
-
-$("#searchForm").submit(function (event){
-  event.preventDefault();
-  q = $("#searchbox").val();
-  url = "{{site.baseurl}}/search/?q=" + q
-  if ($("#chapterCheckbox").prop("checked")){
-    url = url + "&chapter=" + window.location.href.split('#')[0].split('chapters/')[1].slice(0,2)
-  }
-  window.location.href = url
-})
+function getParameterByName(name) {
+  name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+  var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
+      results = regex.exec(location.search);
+  return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+}
 
 $(document).ready(function(){
+  $("#searchForm").submit(function (event){
+    event.preventDefault();
+    q = $("#searchbox").val();
+    url = "{{site.baseurl}}/search/?q=" + q
+    if ($("#chapterCheckbox").prop("checked")){
+      url = url + "&chapter=" + window.location.href.split('#')[0].split('chapters/')[1].slice(0,2)
+    }
+    window.location.href = url
+  })
+
   var q = getParameterByName('q');
   if (q) {
     $("#searchbox").val(q)
   }
-})
-
-function getParameterByName(name) {
-    name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
-    var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
-        results = regex.exec(location.search);
-    return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
-}
+});


### PR DESCRIPTION
        Currently search on a chapter page is working, but search on the
        home page fails. It looks like the id for the form is different
        on the home page. This commit fixes that, but the real fix is a
        partial of some sort that both pages use.

        Also, there is a hidden race condition, where the listener on
        the form is not in a $(document).ready block, so there is the
        possibility that the listener will not attach. This commit also moves
        that listener into the ready block.

        I am not able to verify these fixes work locally, because I
        can't get this code to operate locally as it does on the server.
        Looking for feedback is slack about what I am doing wrong.

        Meanwhile, this can be checked by someone else. @vzvenyach @adelevie 

        Oh, also whitespace fixes. Sorry this is globbed in, my IDE screams with the trailing whitespace.