### PR TITLE
Navigation between chapters

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,3 +30,25 @@ page_gen:
     template: 'chapter'
     name: 'chapter'
     dir: 'chapters'
+    
+chapters:
+  - 10
+  - 11
+  - 12
+  - 13
+  - 14
+  - 15
+  - 16
+  - 20
+  - 21
+  - 22
+  - 23
+  - 24
+  - 25
+  - 30
+  - 31
+  - 32
+  - 33
+  - 36
+  - 39
+  - 46

--- a/_layouts/chapter.html
+++ b/_layouts/chapter.html
@@ -21,7 +21,9 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
-                    {% for chapter in site.data.toc %} {% assign chunks = page.url | split:'/' %}
+                    {% assign chunks = page.url | split:'/' %}
+                    {% assign currentPage = chunks[2] %}
+                    {% for chapter in site.data.toc %} 
                     <a href="/chapters/{{chapter[0]}}" class="list-group-item {% if chapter[0] == chunks[2] %} active {% endif %}">{{ chapter[1].chapter | upcase }}
                     </a> {% endfor %}
                 </ul>
@@ -31,7 +33,19 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter {{ page.chapter }}</h2>
+        {% assign indexOfCurrentChapter = nil %}
+        {% for ch in site.chapters %}
+          {% assign chNum = ch | plus: 0 %}
+          {% assign currPage = currentPage | plus: 0 %}
+          {% if chNum == currPage %}
+            {% assign indexOfCurrentChapter = forloop.index0 %}
+          {% endif %}
+        {% endfor %}
+        {% assign indexOfPrevChapter = indexOfCurrentChapter | minus: 1 %}
+        {% assign indexOfNextChapter = indexOfCurrentChapter | plus: 1 %}
+        {% assign prevChapter = site.chapters[indexOfPrevChapter] %}
+        {% assign nextChapter = site.chapters[indexOfNextChapter] %}
+        <h2>Chapter {{ page.chapter }} <small>(<a href="{{site.baseurl}}/chapters/{{prevChapter}}">Previous Chapter</a> | <a href="{{site.baseurl}}/chapters/{{nextChapter}}">Next Chapter</a>)</small></h2>
         <ul>
             {% for section in page.sections %}
             <li><a href="{{site.baseurl}}/chapters/{{chunks[2]}}#{{section.section}}">{{section.section_title}}</a></li>

--- a/_site/chapters/10/index.html
+++ b/_site/chapters/10/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item  active ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 10</h2>
+        
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 10 <small>(<a href="/chapters/46">Previous Chapter</a> | <a href="/chapters/11">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/10#10a00">10a00 - Purpose of chapter.</a></li>

--- a/_site/chapters/11/index.html
+++ b/_site/chapters/11/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 11</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 11 <small>(<a href="/chapters/10">Previous Chapter</a> | <a href="/chapters/12">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/11#11L00">11L00 - Local or

--- a/_site/chapters/12/index.html
+++ b/_site/chapters/12/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 12</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 12 <small>(<a href="/chapters/11">Previous Chapter</a> | <a href="/chapters/13">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/12#12a00">12a00 - Statutory definition and IB.</a></li>

--- a/_site/chapters/13/index.html
+++ b/_site/chapters/13/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 13</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 13 <small>(<a href="/chapters/12">Previous Chapter</a> | <a href="/chapters/14">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/13#13a00">13a00 - General basis for coverage.</a></li>

--- a/_site/chapters/14/index.html
+++ b/_site/chapters/14/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 14</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 14 <small>(<a href="/chapters/13">Previous Chapter</a> | <a href="/chapters/15">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/14#14L00">14L00 - Payroll and record keeping requirements.</a></li>

--- a/_site/chapters/15/index.html
+++ b/_site/chapters/15/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 15</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 15 <small>(<a href="/chapters/14">Previous Chapter</a> | <a href="/chapters/16">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/15#15a0">15a0l - The Davis-Bacon Act.</a></li>

--- a/_site/chapters/16/index.html
+++ b/_site/chapters/16/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 16</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 16 <small>(<a href="/chapters/15">Previous Chapter</a> | <a href="/chapters/20">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/16#16a00">16a00 - Use of Chapter 16.</a></li>

--- a/_site/chapters/20/index.html
+++ b/_site/chapters/20/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 20</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 20 <small>(<a href="/chapters/16">Previous Chapter</a> | <a href="/chapters/21">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/20#20a00">20a00 - General.</a></li>

--- a/_site/chapters/21/index.html
+++ b/_site/chapters/21/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 21</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 21 <small>(<a href="/chapters/20">Previous Chapter</a> | <a href="/chapters/22">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/21#21a00">21a00 - General provisions.</a></li>

--- a/_site/chapters/22/index.html
+++ b/_site/chapters/22/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 22</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 22 <small>(<a href="/chapters/21">Previous Chapter</a> | <a href="/chapters/23">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/22#22a00">22a00. Regulations: part 541 (29 CFR part 541).</a></li>

--- a/_site/chapters/23/index.html
+++ b/_site/chapters/23/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 23</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 23 <small>(<a href="/chapters/22">Previous Chapter</a> | <a href="/chapters/24">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/23#23a00">23a00 - General provisions.</a></li>

--- a/_site/chapters/24/index.html
+++ b/_site/chapters/24/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 24</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 24 <small>(<a href="/chapters/23">Previous Chapter</a> | <a href="/chapters/25">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/24#24L00">24L00  General.</a></li>

--- a/_site/chapters/25/index.html
+++ b/_site/chapters/25/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 25</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 25 <small>(<a href="/chapters/24">Previous Chapter</a> | <a href="/chapters/30">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/25#25L00">25L00. Statutory provisions.</a></li>

--- a/_site/chapters/30/index.html
+++ b/_site/chapters/30/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 30</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 30 <small>(<a href="/chapters/25">Previous Chapter</a> | <a href="/chapters/31">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/30#30a00">30a00 - Statutory basis.</a></li>

--- a/_site/chapters/31/index.html
+++ b/_site/chapters/31/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 31</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 31 <small>(<a href="/chapters/30">Previous Chapter</a> | <a href="/chapters/32">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/31#31a00">31a00. Employees sent home for lack of work.</a></li>

--- a/_site/chapters/32/index.html
+++ b/_site/chapters/32/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 32</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 32 <small>(<a href="/chapters/31">Previous Chapter</a> | <a href="/chapters/33">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/32#32L00">32L00  Public agency employment may qualify under Sec 7(b).</a></li>

--- a/_site/chapters/33/index.html
+++ b/_site/chapters/33/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 33</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 33 <small>(<a href="/chapters/32">Previous Chapter</a> | <a href="/chapters/36">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/33#33a00">33a00.   Statutory provisions, regulations, and interpretative

--- a/_site/chapters/36/index.html
+++ b/_site/chapters/36/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 36</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 36 <small>(<a href="/chapters/33">Previous Chapter</a> | <a href="/chapters/39">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/36#36a00">36a00 - History.</a></li>

--- a/_site/chapters/39/index.html
+++ b/_site/chapters/39/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 39</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+          
+          
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 39 <small>(<a href="/chapters/36">Previous Chapter</a> | <a href="/chapters/46">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/39#39L00">39L00 - General.</a></li>

--- a/_site/chapters/46/index.html
+++ b/_site/chapters/46/index.html
@@ -59,6 +59,8 @@
             </div>
             <div class="panel-body">
                 <ul class="list-group">
+                    
+                    
                      
                     <a href="/chapters/10" class="list-group-item ">CHAPTER 10 - FLSA COVERAGE - EMPLOYMENT RELATIONSHIP, STATUTORY EXCLUSIONS, GEOGRAPHICAL LIMITS
                     </a>  
@@ -107,7 +109,95 @@
     <!--<div class="col-md-1">
             </div>-->
     <div class="col-md-8">
-        <h2>Chapter 46</h2>
+        
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+        
+          
+          
+          
+            
+          
+        
+        
+        
+        
+        
+        <h2>Chapter 46 <small>(<a href="/chapters/39">Previous Chapter</a> | <a href="/chapters/">Next Chapter</a>)</small></h2>
         <ul>
             
             <li><a href="/chapters/46#46a00">46a00 - Purpose.</a></li>

--- a/_site/data/toc/32.json
+++ b/_site/data/toc/32.json
@@ -1,3 +1,279 @@
 {
-  "chapter": "CHAPTER 32 - OVERTIME"
+  "chapter": "CHAPTER 32 - OVERTIMETABLE OF CONTENTS",
+  "results": [
+    {
+      "sections": []
+    },
+    {
+      "subchapter": "32a - STATUTORY AND REGULATORY PROVISIONS",
+      "sections": [
+        "32a00 - Interpretations and instructions.",
+        "32a01 - Application of partial OT exemptions."
+      ]
+    },
+    {
+      "subchapter": "32b - REGULAR RATE OF PAY   32b00 - Computation of regular rate of pay.  32b",
+      "sections": []
+    },
+    {
+      "subchapter": "00a - Regular rate for w/w’s in which employee receives      no pay or only partial payment.  32b01 - Hourly rate employees.  32b",
+      "sections": []
+    },
+    {
+      "subchapter": "01a - Hourly rate employees paid semimonthly or      monthly.",
+      "sections": [
+        "32b02 - Pieceworkers.",
+        "32b03 - Day rates and job rates.",
+        "32b04 - Salaried employees.  32b"
+      ]
+    },
+    {
+      "subchapter": "04a - General rule.  32b",
+      "sections": []
+    },
+    {
+      "subchapter": "04b - Irregular hours worked.",
+      "sections": [
+        "32b05 - Employees employed at two rates.",
+        "32b06 - Payments other than cash.",
+        "32b07 - PM’s (push money) and other wage payments made by      suppliers.",
+        "32b08 - Annual salary earned in shorter period - regular      rate."
+      ]
+    },
+    {
+      "subchapter": "32c - BONUSES",
+      "sections": [
+        "32c00 - Bonuses as a part of the regular rate.",
+        "32c01 - Discretionary bonuses.",
+        "32c02 - Profit-sharing plans or trusts.",
+        "32c03 - How a bonus is to be included in the regular      rate.",
+        "32c04 - Distribution of bonuses as a percentage of total      earnings or by the boosted hour method.",
+        "32c05 - Methods of distributing bonuses.  32c"
+      ]
+    },
+    {
+      "subchapter": "05a - Bonuses on total earnings.  32c",
+      "sections": []
+    },
+    {
+      "subchapter": "05b - Bonuses on hours.  32c",
+      "sections": []
+    },
+    {
+      "subchapter": "05c - Distribution according to length of service and      similar factors.",
+      "sections": []
+    },
+    {
+      "subchapter": "32d - OTHER REMUNERATION WHICH MAY BE EXCLUDABLE FROM COMPUTATION OF REGULAR RATE",
+      "sections": [
+        "32d00 - Sums paid as gifts.",
+        "32d01 - Payments for suggestions.",
+        "32d02 - New business contents awards",
+        "32d03 - Payments for absences, holidays, or leave.  32d"
+      ]
+    },
+    {
+      "subchapter": "03a - Payment for occasional absences.  32d",
+      "sections": []
+    },
+    {
+      "subchapter": "03b - Holiday defined.  32d",
+      "sections": []
+    },
+    {
+      "subchapter": "03c - Permissive counting of excused absence in      computing OT.  32d",
+      "sections": []
+    },
+    {
+      "subchapter": "03d - Payment of OT by an additional period of vacation      with pay.  32d",
+      "sections": []
+    },
+    {
+      "subchapter": "03e - Payment for foregoing a vacation or sick leave.  32d",
+      "sections": []
+    },
+    {
+      "subchapter": "03f - Compensation for day before or after a holiday.  32d",
+      "sections": []
+    },
+    {
+      "subchapter": "03g - Annual leave plan.  32d",
+      "sections": []
+    },
+    {
+      "subchapter": "03h - Fringe benefits paid in cash.  32d04 - Report and callback pay.  32d",
+      "sections": []
+    },
+    {
+      "subchapter": "04a - General rule.  32d",
+      "sections": []
+    },
+    {
+      "subchapter": "04b - Report and callback rule not restricted to      arrangements which are so designated.  32d",
+      "sections": []
+    },
+    {
+      "subchapter": "04c - ST pay provisions in a callback agreement.  32d",
+      "sections": []
+    },
+    {
+      "subchapter": "04d - Rest period payments may be treated as callback      payments.  32d05 - Reimbursement of employee expenses.  32d",
+      "sections": []
+    },
+    {
+      "subchapter": "05a - General rule.  32d",
+      "sections": []
+    },
+    {
+      "subchapter": "05b - Payment for travel time.  32d",
+      "sections": []
+    },
+    {
+      "subchapter": "05c - Employer’s share of board and lodging cost.",
+      "sections": [
+        "32d06 - Benefit plans.",
+        "32d07 - Thrift and savings plans.",
+        "32d08 - Talent fees.  32d"
+      ]
+    },
+    {
+      "subchapter": "08a - Radio and television broadcasting.  32d",
+      "sections": []
+    },
+    {
+      "subchapter": "08b - Offsetting talent fees against OT.",
+      "sections": [
+        "32d09 - D-B Act fringe benefits payments.",
+        "32d10 - Piece rate premium pay under Sec 7(e)(5)."
+      ]
+    },
+    {
+      "subchapter": "32e - PREMIUM RATES FOR EXCESSIVE HOURS",
+      "sections": [
+        "32e00 - Premium payments for excessive hours.",
+        "32e01 - Valid hours standards.",
+        "32e02 - Questionable hours standard.",
+        "32e03 - Offset of premium payments for excessive hours.",
+        "32e04 - Premium rates for specified days."
+      ]
+    },
+    {
+      "subchapter": "32f - PREMIUM RATES FOR WORK OUTSIDE THE BASIC WORKDAY OR BASIC W/W",
+      "sections": [
+        "32f00 - General rule.",
+        "32f01 - Effect of regular practice where agreement does      not specifically designate an hours  standard workday.",
+        "32f02 - Employment contract."
+      ]
+    },
+    {
+      "subchapter": "32g - GUARANTEED WEEKLY WAGE PLANS (FLSA SEC 7(f))",
+      "sections": [
+        "32g00 - FLSA Sec 7(f).",
+        "32g01 - Contract or agreement.",
+        "32g02 - Irregular hours.",
+        "32g03 - Agreements covering more than one employee.",
+        "32g04 - Payment of the guaranty and for hours in excess      of guaranty deductions.",
+        "32g05 - Regular rate in relation to guaranty -      “excessivity” standard not controlling.",
+        "32g06 - Guaranty of pay for not more than 60 hours in a      w/w.",
+        "32g07 - Computations, invalid Sec 7(f) plans.",
+        "32g08 - Sec 7(f) plans and the PCA.",
+        "32g09 - Exempt w/w’s."
+      ]
+    },
+    {
+      "subchapter": "32h - OT BASED ON RATE FOR SAME WORK WHEN PERFORMED DURING NON-OT HOURS",
+      "sections": [
+        "32h00 - General provisions of FLSA Sec 7(g)(l) and      7(g)(2).",
+        "32h01 - Prior agreement or understanding.",
+        "32h02 - Two or more kinds of work for which different      rates of pay have been established.",
+        "32h03 - Bona fide rates — FLSA Sees 7(g)(l) and 7(g)(2).",
+        "32h04 - OT compensation on other forms of pay.",
+        "32h05 - Number of hours for which compensation is due.",
+        "32h06 - Computation under FLSA Sec 7(g)(2) when one of      the rates is averaged ."
+      ]
+    },
+    {
+      "subchapter": "32i - OT BASED ON RATE ESTABLISHED AS OT RATE BY AGREEMENT OR UNDERSTANDING",
+      "sections": [
+        "32i00 - General provisions of FLSA Sec 7(g)(3).",
+        "32i01 - Payments under Reg 548.",
+        "32i02 - Public agencies may utilize Sec 7(g)."
+      ]
+    },
+    {
+      "subchapter": "32j - SPECIAL OT PROBLEMS",
+      "sections": [
+        "32j00 - Multiple minima where records do not show      segregation.",
+        "32j01 - Multiple minima under State, Territorial, and      U.S. laws.",
+        "32j02 - ST compensation to be paid in full.",
+        "32j03 -            Owner-operators of equipment.",
+        "32j04 - Wage raises cannot cover OT.",
+        "32j05 - Changes in scheduled hours without change in pay.",
+        "32j06 -            Lump-sum OT payment.",
+        "32j07- Retroactive increases.",
+        "32j08 -            Deductions in OT weeks.",
+        "32j09 -            Payments for activities not normally      hours worked.",
+        "32j10 -            Delayed payment of OT compensation.",
+        "32j11 -            Semimonthly or monthly payments which      include OT.",
+        "32j12 -            Concurrently working for more than      one employer.",
+        "32j13 -            Change of w/w.",
+        "32j14 -            Stint or task system.  32j"
+      ]
+    },
+    {
+      "subchapter": "14a - Characteristics.  32j",
+      "sections": []
+    },
+    {
+      "subchapter": "14b - The stint as an hours standard.  32j",
+      "sections": []
+    },
+    {
+      "subchapter": "14c - Application of Sec 7(g)(l) or (2).  32j",
+      "sections": []
+    },
+    {
+      "subchapter": "14d - IB 778.312 distinguished.  32jl",
+      "sections": []
+    },
+    {
+      "subchapter": "4e - Variations in plans.  32j",
+      "sections": []
+    },
+    {
+      "subchapter": "14f - Stint or task basis of payment in other      industries.",
+      "sections": [
+        "32j15 - Wage pool arrangement.",
+        "32j16 - Time off and prepayment plans.  32j"
+      ]
+    },
+    {
+      "subchapter": "16a - Basic requirements to be considered.  32j",
+      "sections": []
+    },
+    {
+      "subchapter": "16b - The time off plan.  32j",
+      "sections": []
+    },
+    {
+      "subchapter": "16c - Prepayment plans.  32j",
+      "sections": []
+    },
+    {
+      "subchapter": "16d - Comparison of the time off and prepayment plans.  32j17 - Domestic service employees.",
+      "sections": []
+    },
+    {
+      "subchapter": "32k - PCA SPECIAL PROBLEMS",
+      "sections": [
+        "32k01 - Exchanging shifts.",
+        "32k02 - Making up lost time."
+      ]
+    },
+    {
+      "subchapter": "32L - SECS 7(b)(1) and 7(b)(2)   32L00 - Public agency employment may qualify under Sec.      7(b).",
+      "sections": []
+    }
+  ]
+>>>>>>> Update to _site folder from adding next and prev links
 }


### PR DESCRIPTION
Works decently well.

Screenshot: 
<img width="817" alt="screen shot 2015-09-25 at 2 29 38 pm" src="https://cloud.githubusercontent.com/assets/86790/10108935/dbd0d8d0-6391-11e5-9650-a9f79e25dabc.png">

Caveats:

- Chapter 10's "previous chapter" is the last chapter, 46. Chapter 46's "next chapter" is "/chapters".
- The chapters are defined in `_config.yml`. Changes to the Word doc content that add or remove chapters should be accompanied by changes to `_config.yml` to ensure parity.
